### PR TITLE
feat: Add recon_weight parameter to Dis2pVI_cE train method

### DIFF
--- a/dis2p/dis2pvi_cE.py
+++ b/dis2p/dis2pvi_cE.py
@@ -311,6 +311,7 @@ class Dis2pVI_cE(
             early_stopping: bool = True,
             save_best: bool = False,
             plan_kwargs: Optional[dict] = None,
+            recon_weight: Tunable[Union[float, int]] = 10, # RECONST_LOSS_X weight
             cf_weight: Tunable[Union[float, int]] = 1,  # RECONST_LOSS_X_CF weight
             beta: Tunable[Union[float, int]] = 1,  # KL Zi weight
             clf_weight: Tunable[Union[float, int]] = 50,  # Si classifier weight
@@ -384,6 +385,7 @@ class Dis2pVI_cE(
             )
             
         training_plan = self._training_plan_cls(self.module,
+                                                recon_weight=recon_weight,
                                                 cf_weight=cf_weight,
                                                 beta=beta,
                                                 clf_weight=clf_weight,


### PR DESCRIPTION
The `recon_weight` parameter is added to the `Dis2pVI_cE` train method, allowing the weight of the reconstruction loss to be tuned. This parameter is used in the module to control the contribution of the reconstruction loss to the overall loss function.