### PR TITLE
chore(training): add n_epochs_pretrain_ae in Dis2pVI_cE and Dis2pTrainingPlan

### DIFF
--- a/dis2p/dis2pvi_cE.py
+++ b/dis2p/dis2pvi_cE.py
@@ -520,6 +520,7 @@ class Dis2pVI_cE(
             adv_period: Tunable[int] = 1,  # adversarial training period
             n_cf: Tunable[int] = 10,  # number of X_cf recons (a random permutation of n VAEs and a random half-batch subset for each trial)
             kappa_optimizer2: bool = True,
+            n_epochs_pretrain_ae: int = 0,
             **trainer_kwargs,
     ):
         """Train the model.
@@ -596,6 +597,7 @@ class Dis2pVI_cE(
                                                 adv_period=adv_period,
                                                 n_cf=n_cf,
                                                 kappa_optimizer2=kappa_optimizer2,
+                                                n_epochs_pretrain_ae=n_epochs_pretrain_ae,
                                                 **plan_kwargs)
 
         es = "early_stopping"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dis2p"
-version = "0.0.9"
+version = "0.0.10"
 description = "To be added."
 authors = ["First Last <name@example.com>"]
 license = "MIT"


### PR DESCRIPTION
Added the `n_epochs_pretrain_ae` parameter in both `Dis2pVI_cE` and `Dis2pTrainingPlan` to allow for pretraining autoencoders. This change ensures proper model initialization and serves as a crucial step before adversarial training, leading to improved system performance.

`n_epochs_pretrain_ae` is to be added in the `train_dict`.